### PR TITLE
feat(db): move config to config file

### DIFF
--- a/Src/Starter.Net.Api/Configs/Database.cs
+++ b/Src/Starter.Net.Api/Configs/Database.cs
@@ -1,0 +1,11 @@
+namespace Starter.Net.Api.Configs
+{
+    public class Database
+    {
+        public string Host { get; set; }
+        public int Port { set; get; }
+        public string Name { set; get; }
+        public string User { set; get; }
+        public string Password { set; get; }
+    }
+}

--- a/Src/Starter.Net.Api/Models/ApplicationContext.cs
+++ b/Src/Starter.Net.Api/Models/ApplicationContext.cs
@@ -1,25 +1,38 @@
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
 using Npgsql;
 using Starter.Net.Api.Authentication;
+using Starter.Net.Api.Configs;
 
 namespace Starter.Net.Api.Models
 {
     public class ApplicationContext: IdentityDbContext
     {
         public DbSet<User> Users { set; get; }
+        private readonly Database _db;
+
+        public ApplicationContext(DbContextOptions options, IOptions<Database> dbOption) : base(options)
+        {
+            _db = dbOption.Value;
+        }
+
+        protected ApplicationContext(IOptions<Database> dbOption)
+        {
+            _db = dbOption.Value;
+        }
 
         protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
         {
             var connection = new NpgsqlConnectionStringBuilder	
             {
-                Host = "localhost",	
-                Port = 15432,	
-                Database = "starter",	
-                Username = "fossapps",	
-                Password = "secret",	
-                SslMode = SslMode.Disable	
+                Host = _db.Host,
+                Port = _db.Port,
+                Database = _db.Name,
+                Username = _db.User,
+                Password = _db.Password,
+                SslMode = SslMode.Disable
             };
             optionsBuilder.UseNpgsql(connection.ConnectionString);
         }

--- a/Src/Starter.Net.Api/Program.cs
+++ b/Src/Starter.Net.Api/Program.cs
@@ -14,7 +14,7 @@ namespace Starter.Net.Api
     {
         public static void Main(string[] args)
         {
-            var webHost = CreateHostBuilder(args).Build();
+            var webHost = CreateWebHostBuilder(args).Build();
             using (var scope = webHost.Services.CreateScope())
             {
                 var serviceProvider = scope.ServiceProvider;
@@ -32,7 +32,7 @@ namespace Starter.Net.Api
             webHost.Run();
         }
 
-        private static IHostBuilder CreateHostBuilder(string[] args) =>
+        private static IHostBuilder CreateWebHostBuilder(string[] args) =>
             Host.CreateDefaultBuilder(args)
                 .ConfigureWebHostDefaults(webBuilder => { webBuilder.UseStartup<Startup>(); });
     }

--- a/Src/Starter.Net.Api/Startup.cs
+++ b/Src/Starter.Net.Api/Startup.cs
@@ -57,6 +57,7 @@ namespace Starter.Net.Api
         private static void AddConfiguration(IServiceCollection services, IConfiguration configuration)
         {
             services.AddSingleton(configuration);
+            services.Configure<Database>(configuration.GetSection("DatabaseConfig"));
             services.Configure<InitDb>(configuration.GetSection("InitDb"));
             services.Configure<Configs.Authentication>(configuration.GetSection("Authentication"));
         }

--- a/Src/Starter.Net.Api/appsettings.json
+++ b/Src/Starter.Net.Api/appsettings.json
@@ -39,5 +39,12 @@
       "Authority": "",
       "Audience": ""
     }
+  },
+  "DatabaseConfig": {
+    "Host": "localhost",
+    "Port": 15432,
+    "Name": "starter",
+    "User": "fossapps",
+    "Password": "secret"
   }
 }


### PR DESCRIPTION
closes #38 
### Today I learnt
since I'm using dotnet core 3 preview as of now, `dotnet new webapi` created a simple project, with two methods namely `Main` and `CreateHostBuilder`, turns out, entity framework cli looks for a method called `CreateWebHostBuilder` in Main program.

`CreateWebHostBuilder` used to be what we had in .NET core 2.1, 2.2 maybe.

I figured that out by adding a `--verbose` which said something like the following:

> Finding DbContext classes...
> Finding IDesignTimeDbContextFactory implementations...
> Finding application service provider...
> Finding IWebHost accessor...
> No CreateWebHostBuilder(string[]) method was found on type 'Starter.Net.Api.Program'.
> No application service provider was found.
> Finding DbContext classes in the project...
> Found DbContext 'ApplicationContext'.
> 

When it doesn't find a CreateWebHostBuilder, it tries to construct DbContext, but since it had not run `ConfigureServices` method, `ef` doesn't know how to inject config.
